### PR TITLE
Add Pose / Transform msg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,21 @@ between ROS 1 and Ignition Transport.
 The bridge is currently implemented in C++. At this point there's no support for
 service calls.Its support is limited to only the following message types:
 
-| ROS 1 type                  | Ignition Transport type      |
-|-----------------------------|:----------------------------:|
-| std_msgs/Header             | ignition::msgs::Header       |
-| std_msgs/String             | ignition::msgs::StringMsg    |
-| geometry_msgs/Quaternion    | ignition::msgs::Quaternion   |
-| geometry_msgs/Vector3       | ignition::msgs::Vector3d     |
-| sensor_msgs/Imu             | ignition::msgs::IMU          |
-| sensor_msgs/Image           | ignition::msgs::Image        |
-| sensor_msgs/LaserScan       | ignition::msgs::LaserScan    |
-| sensor_msgs/MagneticField   | ignition::msgs::Magnetometer |
+| ROS 1 type                     | Ignition Transport type      |
+|--------------------------------|:----------------------------:|
+| std_msgs/Header                | ignition::msgs::Header       |
+| std_msgs/String                | ignition::msgs::StringMsg    |
+| geometry_msgs/Quaternion       | ignition::msgs::Quaternion   |
+| geometry_msgs/Vector3          | ignition::msgs::Vector3d     |
+| geometry_msgs/Point            | ignition::msgs::Vector3d     |
+| geometry_msgs/Pose             | ignition::msgs::Pose         |
+| geometry_msgs/PoseStamped      | ignition::msgs::Pose         |
+| geometry_msgs/Transform        | ignition::msgs::Pose         |
+| geometry_msgs/TransformStamped | ignition::msgs::Pose         |
+| sensor_msgs/Imu                | ignition::msgs::IMU          |
+| sensor_msgs/Image              | ignition::msgs::Image        |
+| sensor_msgs/LaserScan          | ignition::msgs::LaserScan    |
+| sensor_msgs/MagneticField      | ignition::msgs::Magnetometer |
 
 Run `parameter_bridge -h` for instructions.
 

--- a/include/ros1_ign_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_ign_bridge/builtin_interfaces_factories.hpp
@@ -17,6 +17,11 @@
 
 // include ROS 1 messages
 #include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Vector3.h>
 #include <sensor_msgs/FluidPressure.h>
 #include <sensor_msgs/Image.h>
@@ -122,6 +127,96 @@ Factory<
 >::convert_ign_to_1(
   const ignition::msgs::Vector3d & ign_msg,
   geometry_msgs::Vector3 & ros1_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Point,
+  ignition::msgs::Vector3d
+>::convert_1_to_ign(
+  const geometry_msgs::Point & ros1_msg,
+  ignition::msgs::Vector3d & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Point,
+  ignition::msgs::Vector3d
+>::convert_ign_to_1(
+  const ignition::msgs::Vector3d & ign_msg,
+  geometry_msgs::Point & ros1_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Pose,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::Pose & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Pose,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Pose & ros1_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseStamped,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::PoseStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseStamped,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::PoseStamped & ros1_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Transform,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::Transform & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::Transform,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Transform & ros1_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::TransformStamped,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::TransformStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+Factory<
+  geometry_msgs::TransformStamped,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::TransformStamped & ros1_msg);
 
 // sensor_msgs
 template<>

--- a/include/ros1_ign_bridge/convert_builtin_interfaces.hpp
+++ b/include/ros1_ign_bridge/convert_builtin_interfaces.hpp
@@ -17,7 +17,12 @@
 
 // include ROS 1 builtin messages
 #include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/FluidPressure.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/Imu.h>
@@ -84,6 +89,66 @@ void
 convert_ign_to_1(
   const ignition::msgs::Vector3d & ign_msg,
   geometry_msgs::Vector3 & ros1_msg);
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::Point & ros1_msg,
+  ignition::msgs::Vector3d & ign_msg);
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Vector3d & ign_msg,
+  geometry_msgs::Point & ros1_msg);
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::Pose & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Pose & ros1_msg);
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::PoseStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::PoseStamped & ros1_msg);
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::Transform & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Transform & ros1_msg);
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::TransformStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg);
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::TransformStamped & ros1_msg);
 
 // sensor_msgs
 template<>

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -73,6 +73,61 @@ get_factory_builtin_interfaces(
     >("geometry_msgs/Vector3", ign_type_name);
   }
   if (
+    (ros1_type_name == "geometry_msgs/Point" || ros1_type_name == "") &&
+     ign_type_name == "ignition.msgs.Vector3d")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::Point,
+        ignition::msgs::Vector3d
+      >
+    >("geometry_msgs/Point", ign_type_name);
+  }
+  if (
+    (ros1_type_name == "geometry_msgs/Pose" || ros1_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::Pose,
+        ignition::msgs::Pose
+      >
+    >("geometry_msgs/Pose", ign_type_name);
+  }
+  if (
+    (ros1_type_name == "geometry_msgs/PoseStamped" || ros1_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::PoseStamped,
+        ignition::msgs::Pose
+      >
+    >("geometry_msgs/PoseStamped", ign_type_name);
+  }
+  if (
+    (ros1_type_name == "geometry_msgs/Transform" || ros1_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::Transform,
+        ignition::msgs::Pose
+      >
+    >("geometry_msgs/Transform", ign_type_name);
+  }
+  if (
+    (ros1_type_name == "geometry_msgs/TransformStamped" || ros1_type_name == "") &&
+     ign_type_name == "ignition.msgs.Pose")
+  {
+    return std::make_shared<
+      Factory<
+        geometry_msgs::TransformStamped,
+        ignition::msgs::Pose
+      >
+    >("geometry_msgs/TransformStamped", ign_type_name);
+  }
+  if (
     (ros1_type_name == "sensor_msgs/FluidPressure" || ros1_type_name == "") &&
      ign_type_name == "ignition.msgs.Fluid")
   {
@@ -253,6 +308,125 @@ Factory<
   ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
 }
 
+template<>
+void
+Factory<
+  geometry_msgs::Point,
+  ignition::msgs::Vector3d
+>::convert_1_to_ign(
+  const geometry_msgs::Point & ros1_msg,
+  ignition::msgs::Vector3d & ign_msg)
+{
+  ros1_ign_bridge::convert_1_to_ign(ros1_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::Point,
+  ignition::msgs::Vector3d
+>::convert_ign_to_1(
+  const ignition::msgs::Vector3d & ign_msg,
+  geometry_msgs::Point & ros1_msg)
+{
+  ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::Pose,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::Pose & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  ros1_ign_bridge::convert_1_to_ign(ros1_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::Pose,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Pose & ros1_msg)
+{
+  ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseStamped,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::PoseStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  ros1_ign_bridge::convert_1_to_ign(ros1_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::PoseStamped,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::PoseStamped & ros1_msg)
+{
+  ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::Transform,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::Transform & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  ros1_ign_bridge::convert_1_to_ign(ros1_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::Transform,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Transform & ros1_msg)
+{
+  ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::TransformStamped,
+  ignition::msgs::Pose
+>::convert_1_to_ign(
+  const geometry_msgs::TransformStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  ros1_ign_bridge::convert_1_to_ign(ros1_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  geometry_msgs::TransformStamped,
+  ignition::msgs::Pose
+>::convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::TransformStamped & ros1_msg)
+{
+  ros1_ign_bridge::convert_ign_to_1(ign_msg, ros1_msg);
+}
 
 // sensor_msgs
 template<>

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -135,6 +135,121 @@ convert_ign_to_1(
 template<>
 void
 convert_1_to_ign(
+  const geometry_msgs::Point & ros1_msg,
+  ignition::msgs::Vector3d & ign_msg)
+{
+  ign_msg.set_x(ros1_msg.x);
+  ign_msg.set_y(ros1_msg.y);
+  ign_msg.set_z(ros1_msg.z);
+}
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Vector3d & ign_msg,
+  geometry_msgs::Point & ros1_msg)
+{
+  ros1_msg.x = ign_msg.x();
+  ros1_msg.y = ign_msg.y();
+  ros1_msg.z = ign_msg.z();
+}
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::Pose & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  convert_1_to_ign(ros1_msg.position, *ign_msg.mutable_position());
+  convert_1_to_ign(ros1_msg.orientation, *ign_msg.mutable_orientation());
+}
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Pose & ros1_msg)
+{
+  convert_ign_to_1(ign_msg.position(), ros1_msg.position);
+  convert_ign_to_1(ign_msg.orientation(), ros1_msg.orientation);
+}
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::PoseStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  convert_1_to_ign(ros1_msg.header, (*ign_msg.mutable_header()));
+  convert_1_to_ign(ros1_msg.pose, ign_msg);
+}
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::PoseStamped & ros1_msg)
+{
+  convert_ign_to_1(ign_msg.header(), ros1_msg.header);
+  convert_ign_to_1(ign_msg, ros1_msg.pose);
+}
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::Transform & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  convert_1_to_ign(ros1_msg.translation , *ign_msg.mutable_position());
+  convert_1_to_ign(ros1_msg.rotation, *ign_msg.mutable_orientation());
+}
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::Transform & ros1_msg)
+{
+  convert_ign_to_1(ign_msg.position(), ros1_msg.translation);
+  convert_ign_to_1(ign_msg.orientation(), ros1_msg.rotation);
+}
+
+template<>
+void
+convert_1_to_ign(
+  const geometry_msgs::TransformStamped & ros1_msg,
+  ignition::msgs::Pose & ign_msg)
+{
+  convert_1_to_ign(ros1_msg.header, (*ign_msg.mutable_header()));
+  convert_1_to_ign(ros1_msg.transform, ign_msg);
+
+  auto newPair = ign_msg.mutable_header()->add_data();
+  newPair->set_key("child_frame_id");
+  newPair->add_value(ros1_msg.child_frame_id);
+}
+
+template<>
+void
+convert_ign_to_1(
+  const ignition::msgs::Pose & ign_msg,
+  geometry_msgs::TransformStamped & ros1_msg)
+{
+  convert_ign_to_1(ign_msg.header(), ros1_msg.header);
+  convert_ign_to_1(ign_msg, ros1_msg.transform);
+  for (auto i = 0; i < ign_msg.header().data_size(); ++i)
+  {
+    auto aPair = ign_msg.header().data(i);
+    if (aPair.key() == "child_frame_id" && aPair.value_size() > 0)
+    {
+      ros1_msg.child_frame_id = aPair.value(0);
+      break;
+    }
+  }
+}
+
+template<>
+void
+convert_1_to_ign(
   const sensor_msgs::FluidPressure & ros1_msg,
   ignition::msgs::Fluid & ign_msg)
 {

--- a/test/launch/test_ign_subscriber.launch
+++ b/test/launch/test_ign_subscriber.launch
@@ -7,6 +7,11 @@
               /string@std_msgs/String@ignition.msgs.StringMsg
               /quaternion@geometry_msgs/Quaternion@ignition.msgs.Quaternion
               /vector3@geometry_msgs/Vector3@ignition.msgs.Vector3d
+              /point@geometry_msgs/Point@ignition.msgs.Vector3d
+              /pose@geometry_msgs/Pose@ignition.msgs.Pose
+              /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
+              /transform@geometry_msgs/Transform@ignition.msgs.Pose
+              /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose
               /image@sensor_msgs/Image@ignition.msgs.Image
               /imu@sensor_msgs/Imu@ignition.msgs.IMU
               /laserscan@sensor_msgs/LaserScan@ignition.msgs.LaserScan

--- a/test/launch/test_ros1_subscriber.launch
+++ b/test/launch/test_ros1_subscriber.launch
@@ -7,6 +7,11 @@
               /string@std_msgs/String@ignition.msgs.StringMsg
               /quaternion@geometry_msgs/Quaternion@ignition.msgs.Quaternion
               /vector3@geometry_msgs/Vector3@ignition.msgs.Vector3d
+              /point@geometry_msgs/Point@ignition.msgs.Vector3d
+              /pose@geometry_msgs/Pose@ignition.msgs.Pose
+              /pose_stamped@geometry_msgs/PoseStamped@ignition.msgs.Pose
+              /transform@geometry_msgs/Transform@ignition.msgs.Pose
+              /transform_stamped@geometry_msgs/TransformStamped@ignition.msgs.Pose
               /image@sensor_msgs/Image@ignition.msgs.Image
               /imu@sensor_msgs/Imu@ignition.msgs.IMU
               /laserscan@sensor_msgs/LaserScan@ignition.msgs.LaserScan

--- a/test/publishers/ign_publisher.cpp
+++ b/test/publishers/ign_publisher.cpp
@@ -70,6 +70,33 @@ int main(int /*argc*/, char **/*argv*/)
   ignition::msgs::Vector3d vector3_msg;
   ros1_ign_bridge::testing::createTestMsg(vector3_msg);
 
+  // ignition::msgs::Point.
+  auto point_pub = node.Advertise<ignition::msgs::Vector3d>("point");
+  ignition::msgs::Vector3d point_msg;
+  ros1_ign_bridge::testing::createTestMsg(point_msg);
+
+  // ignition::msgs::Pose.
+  auto pose_pub = node.Advertise<ignition::msgs::Pose>("pose");
+  ignition::msgs::Pose pose_msg;
+  ros1_ign_bridge::testing::createTestMsg(pose_msg);
+
+  // ignition::msgs::PoseStamped.
+  auto pose_stamped_pub = node.Advertise<ignition::msgs::Pose>("pose_stamped");
+  ignition::msgs::Pose pose_stamped_msg;
+  ros1_ign_bridge::testing::createTestMsg(pose_stamped_msg);
+
+  // ignition::msgs::Transform.
+  auto transform_pub =
+      node.Advertise<ignition::msgs::Pose>("transform");
+  ignition::msgs::Pose transform_msg;
+  ros1_ign_bridge::testing::createTestMsg(transform_msg);
+
+  // ignition::msgs::TransformStamped.
+  auto transform_stamped_pub =
+      node.Advertise<ignition::msgs::Pose>("transform_stamped");
+  ignition::msgs::Pose transform_stamped_msg;
+  ros1_ign_bridge::testing::createTestMsg(transform_stamped_msg);
+
   // ignition::msgs::Image.
   auto image_pub = node.Advertise<ignition::msgs::Image>("image");
   ignition::msgs::Image image_msg;
@@ -97,6 +124,11 @@ int main(int /*argc*/, char **/*argv*/)
     string_pub.Publish(string_msg);
     quaternion_pub.Publish(quaternion_msg);
     vector3_pub.Publish(vector3_msg);
+    point_pub.Publish(point_msg);
+    pose_pub.Publish(pose_msg);
+    pose_stamped_pub.Publish(pose_stamped_msg);
+    transform_pub.Publish(transform_msg);
+    transform_stamped_pub.Publish(transform_stamped_msg);
     image_pub.Publish(image_msg);
     imu_pub.Publish(imu_msg);
     laserscan_pub.Publish(laserscan_msg);

--- a/test/publishers/ros1_publisher.cpp
+++ b/test/publishers/ros1_publisher.cpp
@@ -19,6 +19,10 @@
 #include <std_msgs/String.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/LaserScan.h>
@@ -54,6 +58,36 @@ int main(int argc, char ** argv)
   geometry_msgs::Vector3 vector3_msg;
   ros1_ign_bridge::testing::createTestMsg(vector3_msg);
 
+  // geometry_msgs::Point.
+  ros::Publisher point_pub =
+    n.advertise<geometry_msgs::Point>("point", 1000);
+  geometry_msgs::Point point_msg;
+  ros1_ign_bridge::testing::createTestMsg(point_msg);
+
+  // geometry_msgs::Pose.
+  ros::Publisher pose_pub =
+    n.advertise<geometry_msgs::Pose>("pose", 1000);
+  geometry_msgs::Pose pose_msg;
+  ros1_ign_bridge::testing::createTestMsg(pose_msg);
+
+  // geometry_msgs::PoseStamped.
+  ros::Publisher pose_stamped_pub =
+    n.advertise<geometry_msgs::PoseStamped>("pose_stamped", 1000);
+  geometry_msgs::PoseStamped pose_stamped_msg;
+  ros1_ign_bridge::testing::createTestMsg(pose_stamped_msg);
+
+  // geometry_msgs::Transform.
+  ros::Publisher transform_pub =
+    n.advertise<geometry_msgs::Transform>("transform", 1000);
+  geometry_msgs::Transform transform_msg;
+  ros1_ign_bridge::testing::createTestMsg(transform_msg);
+
+  // geometry_msgs::TransformStamped.
+  ros::Publisher transform_stamped_pub =
+    n.advertise<geometry_msgs::TransformStamped>("transform_stampted", 1000);
+  geometry_msgs::TransformStamped transform_stamped_msg;
+  ros1_ign_bridge::testing::createTestMsg(transform_stamped_msg);
+
   // sensor_msgs::Image.
   ros::Publisher image_pub =
     n.advertise<sensor_msgs::Image>("image", 1000);
@@ -85,6 +119,11 @@ int main(int argc, char ** argv)
     string_pub.publish(string_msg);
     quaternion_pub.publish(quaternion_msg);
     vector3_pub.publish(vector3_msg);
+    point_pub.publish(point_msg);
+    pose_pub.publish(pose_msg);
+    pose_stamped_pub.publish(pose_stamped_msg);
+    transform_pub.publish(transform_msg);
+    transform_stamped_pub.publish(transform_stamped_msg);
     image_pub.publish(image_msg);
     imu_pub.publish(imu_msg);
     laserscan_pub.publish(laserscan_msg);

--- a/test/subscribers/ign_subscriber.cpp
+++ b/test/subscribers/ign_subscriber.cpp
@@ -96,6 +96,66 @@ TEST(IgnSubscriberTest, Vector3)
 }
 
 /////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Point)
+{
+  MyTestClass<ignition::msgs::Vector3d> client("point");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Pose)
+{
+  MyTestClass<ignition::msgs::Pose> client("pose");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(IgnSubscriberTest, PoseStamped)
+{
+  MyTestClass<ignition::msgs::Pose> client("pose_stamped");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(IgnSubscriberTest, Transform)
+{
+  MyTestClass<ignition::msgs::Pose> client("transform");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(IgnSubscriberTest, TransformStamped)
+{
+  MyTestClass<ignition::msgs::Pose> client("transform_stamped");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVar(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
 TEST(IgnSubscriberTest, Image)
 {
   MyTestClass<ignition::msgs::Image> client("image");

--- a/test/subscribers/ros1_subscriber.cpp
+++ b/test/subscribers/ros1_subscriber.cpp
@@ -19,6 +19,11 @@
 #include <ros/ros.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
 #include <sensor_msgs/Image.h>
@@ -96,6 +101,66 @@ TEST(ROS1SubscriberTest, Quaternion)
 TEST(ROS1SubscriberTest, Vector3)
 {
   MyTestClass<geometry_msgs::Vector3> client("vector3");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, Point)
+{
+  MyTestClass<geometry_msgs::Point> client("point");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, Pose)
+{
+  MyTestClass<geometry_msgs::Pose> client("pose");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, PoseStamped)
+{
+  MyTestClass<geometry_msgs::PoseStamped> client("pose_stamped");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, Transform)
+{
+  MyTestClass<geometry_msgs::Transform> client("transform");
+
+  using namespace std::chrono_literals;
+  ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(
+    client.callbackExecuted, 10ms, 200);
+
+  EXPECT_TRUE(client.callbackExecuted);
+}
+
+/////////////////////////////////////////////////
+TEST(ROS1SubscriberTest, TransformStamped)
+{
+  MyTestClass<geometry_msgs::TransformStamped> client("transform_stamped");
 
   using namespace std::chrono_literals;
   ros1_ign_bridge::testing::waitUntilBoolVarAndSpin(

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -22,6 +22,11 @@
 #include <ros/ros.h>
 #include <std_msgs/Header.h>
 #include <std_msgs/String.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
 #include <sensor_msgs/Image.h>
@@ -171,6 +176,97 @@ namespace testing
     EXPECT_EQ(1, _msg.x);
     EXPECT_EQ(2, _msg.y);
     EXPECT_EQ(3, _msg.z);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::Point &_msg)
+  {
+    _msg.x = 1;
+    _msg.y = 2;
+    _msg.z = 3;
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::Point &_msg)
+  {
+    geometry_msgs::Point expected_msg;
+    createTestMsg(expected_msg);
+
+    EXPECT_EQ(expected_msg.x, _msg.x);
+    EXPECT_EQ(expected_msg.y, _msg.y);
+    EXPECT_EQ(expected_msg.z, _msg.z);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::Pose &_msg)
+  {
+    createTestMsg(_msg.position);
+    createTestMsg(_msg.orientation);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::Pose &_msg)
+  {
+    compareTestMsg(_msg.position);
+    compareTestMsg(_msg.orientation);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::PoseStamped &_msg)
+  {
+    createTestMsg(_msg.header);
+    createTestMsg(_msg.pose);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::PoseStamped &_msg)
+  {
+    compareTestMsg(_msg.header);
+    compareTestMsg(_msg.pose);
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::Transform &_msg)
+  {
+    createTestMsg(_msg.translation);
+    createTestMsg(_msg.rotation);
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::Transform &_msg)
+  {
+    compareTestMsg(_msg.translation);
+    compareTestMsg(_msg.rotation);
+  }
+
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(geometry_msgs::TransformStamped &_msg)
+  {
+    createTestMsg(_msg.header);
+    createTestMsg(_msg.transform);
+    _msg.child_frame_id = "child_frame_id_value";
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const geometry_msgs::TransformStamped &_msg)
+  {
+    geometry_msgs::TransformStamped expected_msg;
+    createTestMsg(expected_msg);
+
+    compareTestMsg(_msg.header);
+    compareTestMsg(_msg.transform);
+    EXPECT_EQ(expected_msg.child_frame_id, _msg.child_frame_id);
   }
 
   /// \brief Create a message used for testing.
@@ -348,7 +444,7 @@ namespace testing
 
     EXPECT_EQ(expected_msg.stamp().sec(),    _msg.stamp().sec());
     EXPECT_EQ(expected_msg.stamp().nsec(),   _msg.stamp().nsec());
-    EXPECT_EQ(2,                             _msg.data_size());
+    EXPECT_GE(_msg.data_size(),              2);
     EXPECT_EQ(expected_msg.data(0).key(),    _msg.data(0).key());
     EXPECT_EQ(1,                             _msg.data(0).value_size());
     std::string value = _msg.data(0).value(0);
@@ -425,6 +521,37 @@ namespace testing
     EXPECT_EQ(expected_msg.x(), _msg.x());
     EXPECT_EQ(expected_msg.y(), _msg.y());
     EXPECT_EQ(expected_msg.z(), _msg.z());
+  }
+
+  /// \brief Create a message used for testing.
+  /// \param[out] _msg The message populated.
+  void createTestMsg(ignition::msgs::Pose &_msg)
+  {
+    createTestMsg(*_msg.mutable_header());
+    auto child_frame_id_entry = _msg.mutable_header()->add_data();
+    child_frame_id_entry->set_key("child_frame_id");
+    child_frame_id_entry->add_value("child_frame_id_value");
+
+    createTestMsg(*_msg.mutable_position());
+    createTestMsg(*_msg.mutable_orientation());
+  }
+
+  /// \brief Compare a message with the populated for testing.
+  /// \param[in] _msg The message to compare.
+  void compareTestMsg(const ignition::msgs::Pose &_msg)
+  {
+    compareTestMsg(_msg.header());
+
+    ignition::msgs::Pose expected_msg;
+    createTestMsg(expected_msg);
+    // child_frame_id
+    EXPECT_EQ(expected_msg.header().data(2).key(), _msg.header().data(2).key());
+    EXPECT_EQ(1, _msg.header().data(2).value_size());
+    EXPECT_EQ(expected_msg.header().data(2).value(0),
+        _msg.header().data(2).value(0));
+
+    compareTestMsg(_msg.position());
+    compareTestMsg(_msg.orientation());
   }
 
   /// \brief Create a message used for testing.


### PR DESCRIPTION
Add conversion between `ign::msgs::Pose` and 
  * `geometry_msgs/Pose`
  * `geometry_msgs/PoseStamped`
  * `geometry_msgs/Transform`
  * `geometry_msgs/TransformStamped`

Unlike previous msgs types, this is a one-to-many mapping. This is possible since the ign::msgs::Pose msg captures most of the fields in the above ROS geometry msgs, with the following exception:
  * `geometry_msgs/TransformStamped`'s `child_frame_id` field. 

Initial plan was to introduce a `frame` field in ignition::msgs::Pose but later examination of the current ros1_ign_bridge implementation reveals that a similar ros msg field, `frame_id`, is being stored in an any field in `ign::msgs::Header`. So I took the same approach and store the `child_frame_id` in the ign header msg.
