### PR TITLE
Missing dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
+find_package(catkin REQUIRED COMPONENTS
+               geometry_msgs
+               roscpp
+               rostest
+               sensor_msgs
+               std_msgs)
 find_package(ignition-common3 QUIET REQUIRED)
 find_package(ignition-transport6 QUIET REQUIRED)
 set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
@@ -41,7 +46,7 @@ foreach(bridge ${bridge_executables})
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
   install(TARGETS ${bridge}
-          DESTINATION lib/${PROJECT_NAME}
+          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 endforeach(bridge)
 

--- a/package.xml
+++ b/package.xml
@@ -7,11 +7,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
+  <depend>rostest</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
 
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
-
 </package>

--- a/package.xml
+++ b/package.xml
@@ -9,11 +9,11 @@
 
   <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
-  <depend>rostest</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
 
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
During the packaging of the package I noted that we have some missing dependencies in the package. I've also include a little fix to use the catkin variable for installing.

I'm assuming that we have no intention to install the tests artifacts: ign_publisher and ros1_publisher.