### PR TITLE
Remove dependency on ign-common

### DIFF
--- a/.travis/build
+++ b/.travis/build
@@ -8,10 +8,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Dependencies.
 echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
-echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-prerelease bionic main" > /etc/apt/sources.list.d/gazebo-prerelease.list
 echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
 apt-get update -qq
-apt-get install -qq -y libignition-common3-dev \
+apt-get install -qq -y libignition-msgs3-dev \
                        libignition-transport6-dev \
                        python-catkin-tools \
                        python-rosdep \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
+
+find_package(ignition-msgs3 QUIET REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs3_VERSION_MAJOR})
+
 find_package(ignition-transport6 QUIET REQUIRED)
 set(IGN_TRANSPORT_VER ${ignition-transport6_VERSION_MAJOR})
 
@@ -35,6 +39,7 @@ foreach(bridge ${bridge_executables})
   )
   target_link_libraries(${bridge}
     ${catkin_LIBRARIES}
+    ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
   install(TARGETS ${bridge}
@@ -61,6 +66,7 @@ foreach(test_publisher ${test_publishers})
   )
   target_link_libraries(${test_publisher}
     ${catkin_LIBRARIES}
+    ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core
     gtest
     gtest_main
@@ -73,6 +79,7 @@ foreach(test_subscriber ${test_subscribers})
     test/subscribers/${test_subscriber}.cpp)
   target_link_libraries(test_${test_subscriber}
     ${catkin_LIBRARIES}
+    ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
 endforeach(test_subscriber)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
-find_package(ignition-common3 QUIET REQUIRED)
 find_package(ignition-transport6 QUIET REQUIRED)
-set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
 set(IGN_TRANSPORT_VER ${ignition-transport6_VERSION_MAJOR})
 
 catkin_package()
@@ -37,7 +35,6 @@ foreach(bridge ${bridge_executables})
   )
   target_link_libraries(${bridge}
     ${catkin_LIBRARIES}
-    ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
   install(TARGETS ${bridge}
@@ -64,7 +61,6 @@ foreach(test_publisher ${test_publishers})
   )
   target_link_libraries(${test_publisher}
     ${catkin_LIBRARIES}
-    ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
     ignition-transport${IGN_TRANSPORT_VER}::core
     gtest
     gtest_main
@@ -77,7 +73,6 @@ foreach(test_subscriber ${test_subscribers})
     test/subscribers/${test_subscriber}.cpp)
   target_link_libraries(test_${test_subscriber}
     ${catkin_LIBRARIES}
-    ignition-common${IGN_COMMON_VER}::ignition-common${IGN_COMMON_VER}
     ignition-transport${IGN_TRANSPORT_VER}::core
   )
 endforeach(test_subscriber)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run the following examples you will also need these ROS 1 packages:
 * `rqt_image_view`
 
 The following Ignition dependencies are also needed:
-* `libignition-common3-dev`
+* `libignition-msgs3-dev`
 * `libignition-transport6-dev`
 
 ### Building the bridge from source

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <exception>
-#include <ignition/common/Image.hh>
 
 #include "ros1_ign_bridge/convert_builtin_interfaces.hpp"
 
@@ -296,63 +295,63 @@ convert_1_to_ign(
   if (ros1_msg.encoding == "mono8")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::L_INT8);
+      ignition::msgs::PixelFormatType::L_INT8);
     num_channels = 1;
     octets_per_channel = 1u;
   }
   else if (ros1_msg.encoding == "mono16")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::L_INT16);
+      ignition::msgs::PixelFormatType::L_INT16);
     num_channels = 1;
     octets_per_channel = 2u;
   }
   else if (ros1_msg.encoding == "rgb8")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::RGB_INT8);
+      ignition::msgs::PixelFormatType::RGB_INT8);
     num_channels = 3;
     octets_per_channel = 1u;
   }
   else if (ros1_msg.encoding == "rgba8")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::RGBA_INT8);
+      ignition::msgs::PixelFormatType::RGBA_INT8);
     num_channels = 4;
     octets_per_channel = 1u;
   }
   else if (ros1_msg.encoding == "bgra8")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::BGRA_INT8);
+      ignition::msgs::PixelFormatType::BGRA_INT8);
     num_channels = 4;
     octets_per_channel = 1u;
   }
   else if (ros1_msg.encoding == "rgb16")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::RGB_INT16);
+      ignition::msgs::PixelFormatType::RGB_INT16);
     num_channels = 3;
     octets_per_channel = 2u;
   }
   else if (ros1_msg.encoding == "bgr8")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::BGR_INT8);
+      ignition::msgs::PixelFormatType::BGR_INT8);
     num_channels = 3;
     octets_per_channel = 1u;
   }
   else if (ros1_msg.encoding == "bgr16")
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::BGR_INT16);
+      ignition::msgs::PixelFormatType::BGR_INT16);
     num_channels = 3;
     octets_per_channel = 2u;
   }
   else
   {
     ign_msg.set_pixel_format(
-      ignition::common::Image::PixelFormatType::UNKNOWN_PIXEL_FORMAT);
+      ignition::msgs::PixelFormatType::UNKNOWN_PIXEL_FORMAT);
     std::cerr << "Unsupported pixel format [" << ros1_msg.encoding << "]"
               << std::endl;
     return;
@@ -378,56 +377,56 @@ convert_ign_to_1(
   unsigned int octets_per_channel;
 
   if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::L_INT8)
+      ignition::msgs::PixelFormatType::L_INT8)
   {
     ros1_msg.encoding = "mono8";
     num_channels = 1;
     octets_per_channel = 1u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::L_INT16)
+      ignition::msgs::PixelFormatType::L_INT16)
   {
     ros1_msg.encoding = "mono16";
     num_channels = 1;
     octets_per_channel = 2u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::RGB_INT8)
+      ignition::msgs::PixelFormatType::RGB_INT8)
   {
     ros1_msg.encoding = "rgb8";
     num_channels = 3;
     octets_per_channel = 1u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::RGBA_INT8)
+      ignition::msgs::PixelFormatType::RGBA_INT8)
   {
     ros1_msg.encoding = "rgba8";
     num_channels = 4;
     octets_per_channel = 1u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::BGRA_INT8)
+      ignition::msgs::PixelFormatType::BGRA_INT8)
   {
     ros1_msg.encoding = "bgra8";
     num_channels = 4;
     octets_per_channel = 1u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::RGB_INT16)
+      ignition::msgs::PixelFormatType::RGB_INT16)
   {
     ros1_msg.encoding = "rgb16";
     num_channels = 3;
     octets_per_channel = 2u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::BGR_INT8)
+      ignition::msgs::PixelFormatType::BGR_INT8)
   {
     ros1_msg.encoding = "bgr8";
     num_channels = 3;
     octets_per_channel = 1u;
   }
   else if (ign_msg.pixel_format() ==
-      ignition::common::Image::PixelFormatType::BGR_INT16)
+      ignition::msgs::PixelFormatType::BGR_INT16)
   {
     ros1_msg.encoding = "bgr16";
     num_channels = 3;

--- a/test/publishers/ign_publisher.cpp
+++ b/test/publishers/ign_publisher.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 #include <string>
 #include <thread>
-#include <ignition/common/Image.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
 #include "../test_utils.h"

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -36,7 +36,6 @@
 #include <chrono>
 #include <string>
 #include <thread>
-#include <ignition/common/Image.hh>
 #include <ignition/msgs.hh>
 
 namespace ros1_ign_bridge
@@ -564,7 +563,7 @@ namespace testing
     _msg.mutable_header()->CopyFrom(header_msg);
     _msg.set_width(320);
     _msg.set_height(240);
-    _msg.set_pixel_format(ignition::common::Image::PixelFormatType::RGB_INT8);
+    _msg.set_pixel_format(ignition::msgs::PixelFormatType::RGB_INT8);
     _msg.set_step(_msg.width() * 3);
     _msg.set_data(std::string(_msg.height() * _msg.step(), '1'));
   }


### PR DESCRIPTION
This requires a new ign-msgs3 release including [this PR](https://bitbucket.org/ignitionrobotics/ign-msgs/pull-requests/94/add-pixel-format-enum/diff).