### PR TITLE
.travis/build: rosdep skip ignition keys

### DIFF
--- a/.travis/build
+++ b/.travis/build
@@ -22,7 +22,9 @@ apt-get install -qq -y libignition-msgs4-dev \
                        ros-melodic-sensor-msgs
 rosdep init
 rosdep update
-rosdep install --from-paths ./ -i -y --rosdistro melodic
+rosdep install --from-paths ./ -i -y --rosdistro melodic \
+  --skip-keys=ignition-sensors2 \
+  --skip-keys=ignition-transport7
 
 # Build.
 source /opt/ros/melodic/setup.bash

--- a/.travis/build
+++ b/.travis/build
@@ -23,6 +23,9 @@ apt-get install -qq -y libignition-msgs4-dev \
 rosdep init
 rosdep update
 rosdep install --from-paths ./ -i -y --rosdistro melodic \
+  --skip-keys=ignition-gazebo2 \
+  --skip-keys=ignition-msgs4 \
+  --skip-keys=ignition-rendering2 \
   --skip-keys=ignition-sensors2 \
   --skip-keys=ignition-transport7
 


### PR DESCRIPTION
to fix the rosdep issue in #17 